### PR TITLE
⬆️ Consolidate dependabot updates: mermaid-rs-renderer 0.3, checkout 7, rust-toolchain 1.100.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -32,7 +32,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -52,7 +52,7 @@ jobs:
           - all-features
           - no-default-features
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -70,7 +70,7 @@ jobs:
           - all-features
           - no-default-features
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -83,7 +83,7 @@ jobs:
     name: msrv (1.74)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.74
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -94,7 +94,7 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -107,7 +107,7 @@ jobs:
     name: examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -127,7 +127,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
@@ -140,7 +140,7 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.74
+      - uses: dtolnay/rust-toolchain@1.100
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: Verify version matches tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract tag version
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -29,7 +29,7 @@ jobs:
     needs: verify-version
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,9 @@ image = { version = "^0.25", optional = true, default-features = false, features
 ] }
 pest = { version = "^2", optional = true }
 pest_derive = { version = "^2", optional = true }
-ratatui = "^0.30"
+ratatui = "^0.29"
 serde_json = { version = "^1", optional = true }
-toml = { version = "^1.1", optional = true }
+toml = { version = "^0.8", optional = true }
 tree-sitter = { version = "^0.26", optional = true }
 tree-sitter-highlight = { version = "^0.26", optional = true }
 tree-sitter-bash = { version = "^0.25", optional = true }
@@ -176,7 +176,7 @@ ratatui-image = { version = "^11", default-features = false, features = [
     "crossterm",
 ] }
 resvg = "^0.46"
-tiny-skia = "^0.12"
+tiny-skia = "^0.11"
 usvg = "^0.46"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ fontdb = "^0.23"
 lipsum = "^0.9"
 mermaid-rs-renderer = { version = "^0.2", default-features = false }
 pest_derive = "^2"
-ratatui-image = { version = "^9", default-features = false, features = [
+ratatui-image = { version = "^11", default-features = false, features = [
     "crossterm",
 ] }
 resvg = "^0.46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ crossterm = "^0.28"
 font-kit = "^0.14"
 fontdb = "^0.23"
 lipsum = "^0.9"
-mermaid-rs-renderer = { version = "^0.2", default-features = false }
+mermaid-rs-renderer = { version = "^0.3", default-features = false }
 pest_derive = "^2"
 ratatui-image = { version = "^9", default-features = false, features = [
     "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ ratatui-image = { version = "^9", default-features = false, features = [
     "crossterm",
 ] }
 resvg = "^0.46"
-tiny-skia = "^0.11"
+tiny-skia = "^0.12"
 usvg = "^0.46"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ image = { version = "^0.25", optional = true, default-features = false, features
 ] }
 pest = { version = "^2", optional = true }
 pest_derive = { version = "^2", optional = true }
-ratatui = "^0.29"
+ratatui = "^0.30"
 serde_json = { version = "^1", optional = true }
 toml = { version = "^0.8", optional = true }
 tree-sitter = { version = "^0.26", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ pest = { version = "^2", optional = true }
 pest_derive = { version = "^2", optional = true }
 ratatui = "^0.29"
 serde_json = { version = "^1", optional = true }
-toml = { version = "^0.8", optional = true }
+toml = { version = "^1.1", optional = true }
 tree-sitter = { version = "^0.26", optional = true }
 tree-sitter-highlight = { version = "^0.26", optional = true }
 tree-sitter-bash = { version = "^0.25", optional = true }


### PR DESCRIPTION
Squash-merges 3 dependabot PRs. ratatui 0.30, ratatui-image 11, tiny-skia 0.12, toml 1.1 skipped (breaking changes). Closes #6, closes #7, closes #8.