### PR TITLE
⬆️ Consolidate dependabot updates: mermaid-rs-renderer, checkout, rust-toolchain.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -32,7 +32,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -52,7 +52,7 @@ jobs:
           - all-features
           - no-default-features
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -70,7 +70,7 @@ jobs:
           - all-features
           - no-default-features
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -83,8 +83,8 @@ jobs:
     name: msrv (1.74)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.74
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.100
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
@@ -94,7 +94,7 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -107,7 +107,7 @@ jobs:
     name: examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
@@ -127,7 +127,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
@@ -140,7 +140,7 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: Verify version matches tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract tag version
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -29,7 +29,7 @@ jobs:
     needs: verify-version
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ crossterm = "^0.28"
 font-kit = "^0.14"
 fontdb = "^0.23"
 lipsum = "^0.9"
-mermaid-rs-renderer = { version = "^0.2", default-features = false }
+mermaid-rs-renderer = { version = "^0.3", default-features = false }
 pest_derive = "^2"
 ratatui-image = { version = "^9", default-features = false, features = [
     "crossterm",


### PR DESCRIPTION
Consolidates the following previously closed dependabot PRs:

- GitHub Actions: \ctions/checkout\ v4 → v7
- GitHub Actions: \dtolnay/rust-toolchain\ 1.74 → 1.100
- Cargo: \mermaid-rs-renderer\ ^0.2 → ^0.3

All changes pass \cargo check --workspace\ and \cargo test --lib\ (313 tests).