### PR TITLE
📝 Fix broken logo URL pointing to dev branch in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/celestia-island/ratatui-markdown/dev/examples/logo.webp" alt="ratatui-markdown logo" width="200" />
+  <img src="https://raw.githubusercontent.com/celestia-island/ratatui-markdown/master/examples/logo.webp" alt="ratatui-markdown logo" width="200" />
 </div>
 
 <div align="center"><h1>ratatui-markdown</h1></div>


### PR DESCRIPTION
The logo image URLs in README referenced the `dev` branch of `docs.celestia.world`, which returns 404. Updated to `master` branch where the images exist.